### PR TITLE
Add -v flag with build-time version to support package managers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
-CFLAGS = -Os -Wall -pedantic
+# Try to get a tag description; if that fails, use branch name + commit
+VERSION := $(shell \
+    git describe --tags --dirty 2>/dev/null || \
+    git describe --all --long --dirty 2>/dev/null | sed -E 's|heads/||; s|-0-|-|' \
+)
+CFLAGS = -Os -Wall -pedantic -DPIKCHR_CMD_VERSION=\"$(VERSION)\"
 
 default: pikchr
-all: default README.md usage.svg
+all: default version README.md usage.svg
 
 pikchr: main.o pikchr.o
 	rm -f $@
 	$(CC) -o $@ main.o pikchr.o -lm
+
+version:
+	./pikchr -v
 
 README.md: README.md.in pikchr
 	./pikchr -S 'title="Click Me!" style="font-size: smaller"' < README.md.in > README.md

--- a/main.c
+++ b/main.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 #include "pikchr.h"
+#include "version.h"
 
 typedef struct {
 	char   *buf;
@@ -123,6 +124,7 @@ static int usage(const char *name, int rv, const char *msg)
 	printf("  -q          -- don't copy non-diagram input to output\n");
 	printf("  -Q          -- remove all diagrams\n");
 	printf("  -N mod      -- only translate diagrams that have modifier mod\n");
+	printf("  -v          -- print version number and exit\n");
 	printf("  -h          -- print this help\n");
 	printf("\n");
 	printf("Zero or more modifiers can follow the start delimiter. Unrecognized\n");
@@ -156,7 +158,7 @@ int main(int argc, char **argv)
 	bool detailsAllDiagrams = false;
 	int rv = 0;
 
-	while((ch = getopt(argc, argv, "c:a:s:S:bpdCRDqQN:h")) != -1)
+	while((ch = getopt(argc, argv, "c:a:s:S:bpdCRDqQN:vh")) != -1)
 	{
 		switch(ch)
 		{
@@ -211,6 +213,10 @@ int main(int argc, char **argv)
 		case 'N':
 			onlyModifier = optarg;
 			break;
+
+		case 'v':
+			printf("pikchr %s\n", PIKCHR_CMD_VERSION);
+			return 0;
 
 		case 'h':
 		default:

--- a/version.h
+++ b/version.h
@@ -1,0 +1,17 @@
+/*
+** version.h -- fallback version header for pikchr command-line tool
+**
+** This header only applies to the CLI wrapper. The version string
+** may be overridden at build time with:
+**
+**   make CFLAGS="-DPIKCHR_CMD_VERSION=\"$(VERSION)\""
+**
+** where VERSION typically comes from `git describe --tags --dirty`.
+** See `Makefile` for details.
+**
+** If no override is provided, the fallback value below is used.
+*/
+
+#ifndef PIKCHR_CMD_VERSION
+#define PIKCHR_CMD_VERSION "unversioned"
+#endif


### PR DESCRIPTION
Adds a `-v` option to print the version number.

The version is injected at build time using `git describe` in the `Makefile`, with `unversioned` as a fallback from `version.h`.

Homebrew and other package managers require a version flag tied to Git tags. Please consider tagging releases (e.g. `1.0.0`) so package managers can track official versions.

**NOTE:** The tag string is shown verbatim in the version output.
Examples:

- Tag `1.0.0` → `pikchr 1.0.0`
- Tag `v1.0.0` → `pikchr v1.0.0`
- Three commits after `1.0.0` with local changes → `pikchr 1.0.0-3-gabc123-dirty`

Builds from untagged commits or dirty working directories automatically include extra commit and state information in the version string, making them easy to distinguish from clean releases.